### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -206,7 +206,8 @@ async def text_to_speech(request: TTSRequest):
         )
 
         if not result["success"]:
-            raise HTTPException(status_code=500, detail=str(result["error"]))
+            logger.error(f"TTS API error: {result['error']}")
+            raise HTTPException(status_code=500, detail="An internal error occurred while processing the TTS request.")
 
         # Decode the base64 audio data
         audio_data = base64.b64decode(result["audio_data"])

--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -128,4 +128,4 @@ class VolcengineTTS:
 
         except Exception as e:
             logger.exception(f"Error in TTS API call: {str(e)}")
-            return {"success": False, "error": str(e), "audio_data": None}
+            return {"success": False, "error": "An internal error occurred in the TTS API.", "audio_data": None}


### PR DESCRIPTION
Potential fix for [https://github.com/pywind/deep-agency/security/code-scanning/1](https://github.com/pywind/deep-agency/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information, such as stack traces or internal error messages, is not exposed to external users. Instead, we should log the detailed error message on the server for debugging purposes and return a generic error message to the client.

1. In `src/tools/tts.py`, ensure that the `error` key in the returned dictionary does not include sensitive information. Replace it with a generic error message.
2. In `src/server/app.py`, modify the `text_to_speech` function to avoid exposing the `result["error"]` message to the client. Instead, log the error and return a generic error message in the `HTTPException`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
